### PR TITLE
libpod 5.0.0 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 ### Added: -
 
 ### Changed:
+* support podman version 5.0.0
+* update dependencies
+* fmt / clean warnings from Df
+
+
+# v0.5.0:
+### Added: -
+
+### Changed:
 * support podman version 4.5.0
 * update dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "podtender"
-version = "0.7.0"
+version = "0.6.0"
 dependencies = [
  "asynchronous-codec",
  "derive_builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "podtender"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "asynchronous-codec",
  "derive_builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -33,10 +48,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.13.1"
+name = "backtrace"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -52,9 +82,9 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
@@ -121,7 +151,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -138,7 +168,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -147,8 +177,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -161,8 +201,22 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -171,22 +225,30 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.4.0"
+name = "darling_macro"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
+ "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -204,7 +266,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -219,6 +281,12 @@ dependencies = [
  "derive_builder_core",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fnv"
@@ -282,7 +350,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -316,19 +384,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "hermit-abi"
-version = "0.2.6"
+name = "hashbrown"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -386,7 +463,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -443,7 +520,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -470,9 +558,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "link-cplusplus"
@@ -518,15 +606,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "mio"
-version = "0.8.6"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
  "libc",
- "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -538,6 +635,12 @@ dependencies = [
  "overload",
  "winapi",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -559,20 +662,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
+name = "object"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
- "hermit-abi",
- "libc",
+ "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "overload"
@@ -600,7 +702,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -611,29 +713,29 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -664,19 +766,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.56"
+name = "powerfmt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -715,10 +823,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "scc"
+version = "2.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c947adb109a8afce5fc9c7bf951f87f146e9147b3a6a58413105628fb1d1e66"
+dependencies = [
+ "sdd",
+]
 
 [[package]]
 name = "scopeguard"
@@ -733,23 +856,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
-name = "serde"
-version = "1.0.160"
+name = "sdd"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "60a7b59a5d9b0099720b417b6325d91a52cbf5b3dcb5041d864be53eefa58abc"
+
+[[package]]
+name = "serde"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -774,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
 dependencies = [
  "percent-encoding",
  "serde",
@@ -785,15 +914,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.2"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331bb8c3bf9b92457ab7abecf07078c13f7d270ba490103e84e8b014490cd0b0"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
  "base64",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -801,39 +932,39 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.2"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859011bddcc11f289f07f467cc1fe01c7a941daa4d8f6c40d4d1c92eb6d9319c"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serial_test"
-version = "2.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
 dependencies = [
- "dashmap",
  "futures",
- "lazy_static",
  "log",
+ "once_cell",
  "parking_lot",
+ "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "2.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -856,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -871,10 +1002,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -889,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -924,7 +1071,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -939,11 +1086,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
+ "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -951,45 +1101,45 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1204,6 +1354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1393,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1419,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1258,6 +1439,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1455,18 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1282,6 +1481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1497,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1306,6 +1517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,3 +1533,9 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podtender"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Julian Schindel <mail@arctic-alpaca.de>"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podtender"
-version = "0.7.0"
+version = "0.6.0"
 edition = "2021"
 authors = [
     "Julian Schindel <mail@arctic-alpaca.de>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "podtender"
 version = "0.7.0"
 edition = "2021"
-authors = ["Julian Schindel <mail@arctic-alpaca.de>"]
+authors = [
+    "Julian Schindel <mail@arctic-alpaca.de>",
+    "Gabe <gmp@gmp.io>"
+]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/PEASEC/podtender"
@@ -72,13 +75,13 @@ hyperlocal = { version = "0.8.0", features = ["client"]}
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_path_to_error = "0.1.7"
-serde_qs = "0.12.0"
-serde_with = {version = "2.0.0", features = ["json", "macros"]}
+serde_qs = "0.13.0"
+serde_with = {version = "3.9.0", features = ["json", "macros"]}
 tracing = {version  ="0.1.34", optional = true}
 thiserror = "1.0.31"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-serial_test = "2.0.0"
+serial_test = "3.1.1"
 tokio = { version = "1.18.1", features = ["rt-multi-thread", "net", "macros", "io-std", "io-util"] }
 tracing-subscriber = {version = "0.3.11", features = ["env-filter", "registry"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podtender"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Julian Schindel <mail@arctic-alpaca.de>"]
 license = "MIT OR Apache-2.0"

--- a/src/containers/parameter_types.rs
+++ b/src/containers/parameter_types.rs
@@ -10,6 +10,36 @@ use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
+pub struct IntelRdt {
+    #[serde(rename = "closID")]
+    pub closid: Option<String>,
+    #[serde(rename = "enableCMT")]
+    pub enable_cmt: Option<bool>,
+    #[serde(rename = "enableMBM")]
+    pub enable_mbm: Option<bool>,
+    #[serde(rename = "l3CacheSchema")]
+    pub l3_cache_schema: Option<String>,
+    #[serde(rename = "memBwSchema")]
+    pub mem_bw_schema: Option<String>,
+}
+
+pub struct StartupHealthConfig {
+    #[serde(rename = "Interval")]
+    pub interval: Option<u64>,
+    #[serde(rename = "Retries")]
+    pub retries: Option<u64>,
+    #[serde(rename = "StartInterval")]
+    pub start_interval: Option<u64>,
+    #[serde(rename = "StartPeriod")]
+    pub start_period: Option<u64>,
+    #[serde(rename = "Sucesses")]
+    pub sucesses: Option<u64>,
+    #[serde(rename = "Test")]
+    pub test: Option<Vec<String>>,
+    #[serde(rename = "Timeout")]
+    pub timeout: Option<u64>,
+}
+
 //json
 #[skip_serializing_none]
 #[cfg_attr(feature = "builder", derive(Builder))]
@@ -18,11 +48,14 @@ use std::convert::TryFrom;
 pub struct CreateContainerParameter {
     pub annotations: Option<HashMap<String, String>>,
     pub apparmor_profile: Option<String>,
+    pub base_hosts_file: Option<String>,
     pub cap_add: Option<String>,
     pub cap_drop: Option<Vec<String>>,
     pub cgroup_parent: Option<String>,
     pub cgroupns: Option<Namespace>,
     pub cgroups_mode: Option<String>,
+    pub chroot_directories: Option<Vec<String>>,
+    pub cni_networks: Option<Vec<String>>,
     pub command: Option<Vec<String>>,
     pub conmon_pid_file: Option<String>,
     #[serde(rename = "containerCreateCommand")]
@@ -41,8 +74,11 @@ pub struct CreateContainerParameter {
     pub entrypoint: Option<Vec<String>>,
     pub env: Option<HashMap<String, String>>,
     pub env_host: Option<bool>,
+    pub envmerge: Option<Vec<String>>,
     pub expose: Option<HashMap<u16, String>>,
+    pub group_entry: Option<Vec<String>>,
     pub groups: Option<Vec<String>>,
+    pub health_check_on_failure_action: Option<u64>,
     pub healthconfig: Option<Schema2HealthConfig>,
     pub host_device_list: Option<Vec<LinuxDevice>>,
     pub hostadd: Option<Vec<String>>,
@@ -51,12 +87,18 @@ pub struct CreateContainerParameter {
     pub httpproxy: Option<bool>,
     pub idmappings: Option<IdMappingOptions>,
     pub image: Option<String>,
+    pub image_arch: Option<String>,
+    pub image_os: Option<String>,
+    pub image_variant: Option<String>,
     pub image_volume_mode: Option<String>,
     pub image_volumes: Option<Vec<ImageVolume>>,
     pub init: Option<bool>,
     pub init_container_type: Option<String>,
     pub init_path: Option<String>,
+    #[serde(rename = "intelRdt")]
+    pub intel_rdt: Option<IntelRdt>,
     pub ipcns: Option<Namespace>,
+    pub label_nested: Option<bool>,
     pub labels: Option<HashMap<String, String>>,
     pub log_configuration: Option<LogConfig>,
     pub manage_password: Option<bool>,
@@ -82,21 +124,28 @@ pub struct CreateContainerParameter {
     pub r_limits: Option<Vec<POSIXRlimit>>,
     pub raw_image_name: Option<String>,
     pub read_only_filesystem: Option<bool>,
+    pub read_write_tmpfs: Option<bool>,
     pub remove: Option<bool>,
+    pub remove_image: Option<bool>,
     pub resource_limits: Option<LinuxResources>,
     pub restart_policy: Option<String>,
     pub restart_tries: Option<u64>,
     pub rootfs: Option<String>,
+    pub rootfs_mapping: Option<String>,
     pub rootfs_overlay: Option<bool>,
     pub rootfs_progagation: Option<String>,
     #[serde(rename = "sdnotifyMode")]
     pub sdnotify_mode: Option<String>,
     pub seccomp_policy: Option<String>,
     pub seccomp_profile_path: Option<String>,
+    pub secret_env: Option<HashMap<String, String>>,
     pub secrets_env: Option<HashMap<String, String>>,
     pub secrets: Option<Vec<Secret>>,
     pub selinux_opts: Option<Vec<String>>,
     pub shm_size: Option<i64>,
+    pub shm_size_systemd: Option<i64>,
+    #[serde(rename = "startupHealthConfig")]
+    pub startup_health_config: Option<StartupHealthConfig>,
     pub stdin: Option<bool>,
     pub stop_signal: Option<i64>,
     pub stop_timeout: Option<u64>,
@@ -195,6 +244,8 @@ pub struct Schema2HealthConfig {
     pub interval: Option<i64>,
     #[serde(rename = "Retries")]
     pub retries: Option<i64>,
+    #[serde(rename = "StartInterval")]
+    pub start_interval: Option<i64>,
     #[serde(rename = "StartPeriod")]
     pub start_period: Option<i64>,
     #[serde(rename = "Test")]
@@ -261,6 +312,8 @@ pub struct ImageVolume {
     pub read_write: Option<bool>,
     #[serde(rename = "Source")]
     pub source: Option<String>,
+    #[serde(rename = "subPath")]
+    pub sub_path: Option<String>,
 }
 
 #[skip_serializing_none]
@@ -281,6 +334,8 @@ pub struct LogConfig {
 pub struct Mount {
     #[serde(rename = "BindOptions")]
     pub bindoptions: Option<BindOptions>,
+    #[serde(rename = "ClusterOptions")]
+    pub cluster_options: Option<String>,
     #[serde(rename = "Consistency")]
     pub consistency: Option<String>,
     #[serde(rename = "ReadOnly")]
@@ -302,10 +357,16 @@ pub struct Mount {
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
 pub struct BindOptions {
+    #[serde(rename = "CreateMountpoint")]
+    pub create_mountpoint: Option<bool>,
     #[serde(rename = "NonRecursive")]
     pub non_recursive: Option<bool>,
     #[serde(rename = "Propagation")]
     pub propagation: Option<String>,
+    #[serde(rename = "ReadOnlyForceRecursive")]
+    pub read_only_force_recursive: Option<bool>,
+    #[serde(rename = "ReadOnlyNonRecursive")]
+    pub read_only_non_recursive: Option<bool>,
 }
 
 #[skip_serializing_none]
@@ -330,6 +391,8 @@ pub struct VolumeOptions {
     pub labels: Option<HashMap<String, String>>,
     #[serde(rename = "NoCopy")]
     pub no_copy: Option<bool>,
+    #[serde(rename = "SubPath")]
+    pub sub_path: Option<String>,
 }
 
 #[skip_serializing_none]
@@ -350,6 +413,8 @@ pub struct DriverConfig {
 pub struct TmpfsOptions {
     #[serde(rename = "Mode")]
     pub mode: Option<u32>,
+    #[serde(rename = "Options")]
+    pub options: Vec<Vec<String>>,
     #[serde(rename = "SizedBytes")]
     pub sized_bytes: Option<i64>,
 }
@@ -455,7 +520,9 @@ pub struct LinuxWeightDevice {
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
 pub struct LinuxCPU {
+    pub burst: Option<i64>,
     pub cpus: Option<String>,
+    pub idle: Option<i64>,
     pub mems: Option<String>,
     pub period: Option<u64>,
     pub quote: Option<i64>,
@@ -494,6 +561,8 @@ pub struct LinuxHugepageLimit {
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
 pub struct LinuxMemory {
+    #[serde(rename = "checkBeforeUpdate")]
+    pub check_before_update: Option<bool>,
     #[serde(rename = "disableOOMKiller")]
     pub disable_oom_killer: Option<bool>,
     pub kernel: Option<i64>,
@@ -718,15 +787,23 @@ pub struct CheckpointContainerParameter {
     #[serde(skip_serializing)]
     pub container_name: String,
     pub export: Option<bool>,
-    #[serde(rename = "IgnoreRootFS")]
+    #[serde(rename = "fileLocks")]
+    pub file_locks: Option<bool>,
+    #[serde(rename = "ignoreRootFS")]
     pub ignore_root_fs: Option<bool>,
+    #[serde(rename= "ignoreVolumes")]
+    pub ignore_volumes: Option<bool>,
     pub keep: Option<bool>,
     #[serde(rename = "leaveRunning")]
     pub leave_running: Option<bool>,
+    #[serde(rename = "preCheckpoint")]
+    pub pre_checkpoint: Option<bool>,
     #[serde(rename = "printStats")]
     pub print_stats: Option<bool>,
     #[serde(rename = "tcpEstablished")]
     pub tcp_established: Option<bool>,
+    #[serde(rename = "withPrevious")]
+    pub with_previous: Option<bool>,
 }
 #[cfg(any(test, feature = "examples"))]
 impl ExampleValues for CheckpointContainerParameter {
@@ -734,11 +811,15 @@ impl ExampleValues for CheckpointContainerParameter {
         Self {
             container_name: String::from("CheckpointContainerParameter"),
             export: Some(true),
+            file_locks: None,
             ignore_root_fs: Some(false),
+            ignore_volumes: None,
             keep: Some(false),
             leave_running: Some(false),
+            pre_checkpoint: None,
             print_stats: Some(false),
             tcp_established: Some(true),
+            with_previous: None,
         }
     }
 }
@@ -927,17 +1008,22 @@ impl ExampleValues for RestartContainerParameter {
 pub struct RestoreContainerParameter {
     #[serde(skip_serializing)]
     pub container_name: String,
+    #[serde(rename = "fileLocks")]
+    pub file_locks: Option<bool>,
     #[serde(rename = "ignoreRootFS")]
     pub ignore_root_fs: Option<bool>,
     #[serde(rename = "ignoreStaticIP")]
     pub ignore_static_ip: Option<bool>,
-    #[serde(rename = "igrnoreStaticMAC")]
+    #[serde(rename = "ignoreStaticMAC")]
     pub ignore_static_mac: Option<bool>,
+    #[serde(rename = "ignoreVolumes")]
+    pub ignore_volumes: Option<bool>,
     pub import: Option<bool>,
     pub keep: Option<bool>,
     #[serde(rename = "leaveRunning")]
     pub leave_running: Option<bool>,
     pub name: Option<String>,
+    pub pod: Option<String>,
     #[serde(rename = "printStats")]
     pub print_stats: Option<bool>,
     #[serde(rename = "tcpEstablished")]
@@ -948,13 +1034,16 @@ impl ExampleValues for RestoreContainerParameter {
     fn example() -> Self {
         Self {
             container_name: String::from("RestoreContainerParameter"),
+            file_locks: None,
             ignore_root_fs: Some(false),
             ignore_static_ip: Some(false),
             ignore_static_mac: Some(false),
+            ignore_volumes: None,
             import: Some(false),
             keep: Some(false),
             leave_running: Some(false),
             name: None,
+            pod: None,
             print_stats: Some(false),
             tcp_established: Some(false),
         }

--- a/src/containers/parameter_types.rs
+++ b/src/containers/parameter_types.rs
@@ -10,6 +10,10 @@ use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
+#[skip_serializing_none]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
 pub struct IntelRdt {
     #[serde(rename = "closID")]
     pub closid: Option<String>,
@@ -23,6 +27,10 @@ pub struct IntelRdt {
     pub mem_bw_schema: Option<String>,
 }
 
+#[skip_serializing_none]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
 pub struct StartupHealthConfig {
     #[serde(rename = "Interval")]
     pub interval: Option<u64>,
@@ -791,7 +799,7 @@ pub struct CheckpointContainerParameter {
     pub file_locks: Option<bool>,
     #[serde(rename = "ignoreRootFS")]
     pub ignore_root_fs: Option<bool>,
-    #[serde(rename= "ignoreVolumes")]
+    #[serde(rename = "ignoreVolumes")]
     pub ignore_volumes: Option<bool>,
     pub keep: Option<bool>,
     #[serde(rename = "leaveRunning")]

--- a/src/containers/response_types.rs
+++ b/src/containers/response_types.rs
@@ -664,6 +664,8 @@ pub struct ContainerStatsResponseInner {
     pub system_nano: Option<u64>,
     #[serde(rename = "UpTime")]
     pub up_time: Option<u64>,
+    #[serde(rename = "Network")]
+    pub network: Option<HashMap<String, HashMap<String, u64>>>
 }
 
 pub type PruneContainerResponseEntry = ErrIdSizeResponse;

--- a/src/containers/response_types.rs
+++ b/src/containers/response_types.rs
@@ -687,7 +687,7 @@ pub struct ContainerStatsResponseInner {
     #[serde(rename = "UpTime")]
     pub up_time: Option<u64>,
     #[serde(rename = "Network")]
-    pub network: Option<HashMap<String, HashMap<String, u64>>>
+    pub network: Option<HashMap<String, HashMap<String, u64>>>,
 }
 
 pub type PruneContainerResponseEntry = ErrIdSizeResponse;

--- a/src/containers/response_types.rs
+++ b/src/containers/response_types.rs
@@ -20,6 +20,8 @@ pub struct CreateContainerResponse {
 pub struct ListContainersResponseEntry {
     #[serde(rename = "AutoRemove")]
     pub auto_remove: Option<bool>,
+    #[serde(rename = "CIDFile")]
+    pub cid_file: Option<String>,
     #[serde(rename = "Command")]
     pub command: Option<Vec<String>>,
     #[serde(rename = "Created")]
@@ -32,6 +34,8 @@ pub struct ListContainersResponseEntry {
     pub exited: Option<bool>,
     #[serde(rename = "ExitedAt")]
     pub exited_at: Option<i64>,
+    #[serde(rename = "ExposedPorts")]
+    pub exposed_ports: Option<HashMap<String, PortMapping>>,
     #[serde(rename = "Id")]
     pub id: Option<String>,
     #[serde(rename = "Image")]
@@ -58,6 +62,8 @@ pub struct ListContainersResponseEntry {
     pub pod_name: Option<String>,
     #[serde(rename = "Ports")]
     pub ports: Option<Vec<PortMapping>>,
+    #[serde(rename = "Restarts")]
+    pub restarts: Option<i64>,
     #[serde(rename = "Size")]
     pub size: Option<ContainerSize>,
     #[serde(rename = "StartedAt")]
@@ -166,6 +172,10 @@ pub struct InspectContainerResponse {
     pub is_infra: Option<bool>,
     #[serde(rename = "IsService")]
     pub is_service: Option<bool>,
+    #[serde(rename = "KubeExitCodePropagation")]
+    pub kube_exit_code_propagation: Option<String>,
+    #[serde(rename = "lockNumber")]
+    pub lock_number: Option<i64>,
     #[serde(rename = "MountLabel")]
     pub mount_label: Option<String>,
     #[serde(rename = "Mounts")]
@@ -215,6 +225,8 @@ pub struct InspectContainerConfig {
     pub attach_stdin: Option<bool>,
     #[serde(rename = "AttachStdout")]
     pub attach_stdout: Option<bool>,
+    #[serde(rename = "ChrootDirs")]
+    pub chroot_dirs: Option<Vec<String>>,
     #[serde(rename = "Cmd")]
     pub cmd: Option<Vec<String>>,
     #[serde(rename = "CreateCommand")]
@@ -222,7 +234,7 @@ pub struct InspectContainerConfig {
     #[serde(rename = "Domainname")]
     pub domainname: Option<String>,
     #[serde(rename = "Entrypoint")]
-    pub entrypoint: Option<String>,
+    pub entrypoint: Option<Vec<String>>,
     #[serde(rename = "Env")]
     pub env: Option<Vec<String>>,
     #[serde(rename = "Healthcheck")]
@@ -298,8 +310,12 @@ pub struct DriverData {
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct InspectContainerHostConfig {
+    #[serde(rename = "Annotations")]
+    pub annotations: HashMap<String, String>,
     #[serde(rename = "AutoRemove")]
     pub auto_remove: Option<bool>,
+    #[serde(rename = "AutoRemoveImage")]
+    pub auto_remove_image: Option<bool>,
     #[serde(rename = "Binds")]
     pub binds: Option<Vec<String>>,
     #[serde(rename = "BlkioDeviceReadBps")]
@@ -366,8 +382,12 @@ pub struct InspectContainerHostConfig {
     pub extra_hosts: Option<Vec<String>>,
     #[serde(rename = "GroupAdd")]
     pub group_add: Option<Vec<String>>,
+    #[serde(rename = "IDMappings")]
+    pub id_mappings: Option<HashMap<String, Vec<String>>>,
     #[serde(rename = "Init")]
     pub init: Option<bool>,
+    #[serde(rename = "IntelRdtClosId")]
+    pub intel_rdt_clos_id: Option<String>,
     #[serde(rename = "IOMaximumBandwidth")]
     pub io_maximum_bandwidth: Option<u64>,
     #[serde(rename = "IOMaximumIOps")]
@@ -536,7 +556,7 @@ pub struct InspectAdditionalNetwork {
     #[serde(rename = "Aliases")]
     pub aliases: Option<Vec<String>>,
     #[serde(rename = "DriverOpts")]
-    pub driver_opts: Option<String>,
+    pub driver_opts: Option<HashMap<String, String>>,
     #[serde(rename = "EndpointID")]
     pub endpoint_id: Option<String>,
     #[serde(rename = "Gateway")]
@@ -612,6 +632,8 @@ pub struct InspectContainerState {
     pub started_at: Option<String>,
     #[serde(rename = "Status")]
     pub status: Option<String>,
+    #[serde(rename = "StoppedByUser")]
+    pub stopped_by_user: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)] //Eq,

--- a/src/images/parameter_types.rs
+++ b/src/images/parameter_types.rs
@@ -162,6 +162,7 @@ impl TryFrom<ListImagesParameter> for ListImagesParameterQuery {
 #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
 pub struct PruneImagesParameter {
     pub all: Option<bool>,
+    pub buildcache: Option<bool>,
     pub external: Option<bool>,
     pub filters: Option<HashMap<String, Vec<String>>>,
 }
@@ -176,6 +177,7 @@ impl ExampleValues for PruneImagesParameter {
         );
         Self {
             all: Some(true),
+            buildcache: Some(false),
             external: Some(false),
             filters: Some(filter_map),
         }

--- a/src/images/response_types.rs
+++ b/src/images/response_types.rs
@@ -70,6 +70,8 @@ pub struct InspectImageResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ImageConfig {
+    #[serde(rename = "ArgsEscaped")]
+    pub args_escaped: Option<bool>,
     #[serde(rename = "Cmd")]
     pub cmd: Option<Vec<String>>,
     #[serde(rename = "Entrypoint")]
@@ -119,6 +121,8 @@ pub struct ImportImageResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ListImagesResponseEntry {
+    #[serde(rename = "Arch")]
+    pub arch: Option<String>,
     #[serde(rename = "ConfigDigest")]
     pub config_digest: Option<String>,
     #[serde(rename = "Containers")]
@@ -133,6 +137,8 @@ pub struct ListImagesResponseEntry {
     pub history: Option<Vec<String>>,
     #[serde(rename = "Id")]
     pub id: Option<String>,
+    #[serde(rename = "IsManifestList")]
+    pub is_manifest_list: Option<bool>,
     #[serde(rename = "Labels")]
     pub labels: Option<HashMap<String, String>>,
     #[serde(rename = "Names")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,4 @@ pub mod example_values_trait;
 
 /// The currently targeted podman api version. Will be used in the requests to the api as follows:
 /// `http://d/{PODMAN_API_VERSION}/libpod/...`
-static PODMAN_API_VERSION: &str = "/v4.4.0";
+static PODMAN_API_VERSION: &str = "/v4.8.0";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,4 @@ pub mod example_values_trait;
 
 /// The currently targeted podman api version. Will be used in the requests to the api as follows:
 /// `http://d/{PODMAN_API_VERSION}/libpod/...`
-static PODMAN_API_VERSION: &str = "/v4.8.0";
+static PODMAN_API_VERSION: &str = "/v5.0.0";

--- a/src/networks/parameter_types.rs
+++ b/src/networks/parameter_types.rs
@@ -103,8 +103,10 @@ pub struct CreateNetworkParameter {
     pub ipv6_enabled: Option<bool>,
     pub labels: Option<HashMap<String, String>>,
     pub name: Option<String>,
+    pub network_dns_servers: Option<Vec<String>>,
     pub network_interface: Option<String>,
     pub options: Option<HashMap<String, String>>,
+    pub routes: Option<Vec<Route>>,
     pub subnets: Option<Vec<Subnet>>,
 }
 
@@ -121,11 +123,24 @@ impl ExampleValues for CreateNetworkParameter {
             ipv6_enabled: None,
             labels: None,
             name: Some("CreateNetworkParameter".to_owned()),
+            network_dns_servers: None,
             network_interface: None,
             options: None,
+            routes: None,
             subnets: None,
         }
     }
+}
+
+#[skip_serializing_none]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+#[serde(deny_unknown_fields)]
+pub struct Route {
+    pub destination: Option<String>,
+    pub gateway: Option<String>,
+    pub metric: Option<u64>,
 }
 
 // also used in InspectNetworkResponse

--- a/src/pods/parameter_types.rs
+++ b/src/pods/parameter_types.rs
@@ -5,6 +5,7 @@ use crate::containers::parameter_types::{
 use crate::error::PodtenderError;
 #[cfg(any(test, feature = "examples"))]
 use crate::example_values_trait::ExampleValues;
+use crate::system::response_types::IdMap;
 use crate::utils;
 #[cfg(feature = "builder")]
 use derive_builder::Builder;
@@ -12,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use crate::system::response_types::IdMap;
 
 #[skip_serializing_none]
 #[cfg_attr(feature = "builder", derive(Builder))]
@@ -50,8 +50,6 @@ pub struct IdMappings {
     #[serde(rename = "UIDMap")]
     pub uid_map: Option<Vec<IdMap>>,
 }
-
-
 
 #[skip_serializing_none]
 #[cfg_attr(feature = "builder", derive(Builder))]

--- a/src/pods/parameter_types.rs
+++ b/src/pods/parameter_types.rs
@@ -12,6 +12,46 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use crate::system::response_types::IdMap;
+
+#[skip_serializing_none]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+pub struct AutoUserNSOpts {
+    #[serde(rename = "AdditionalGIDMappings")]
+    pub additional_gid_mappings: Option<Vec<IdMap>>,
+    #[serde(rename = "AdditionalUIDMappings")]
+    pub additional_uid_mappings: Option<Vec<IdMap>>,
+    #[serde(rename = "GroupFile")]
+    pub group_file: Option<String>,
+    #[serde(rename = "InitialSize")]
+    pub initial_size: Option<u32>,
+    #[serde(rename = "PasswdFile")]
+    pub passwd_file: Option<String>,
+    #[serde(rename = "Size")]
+    pub size: Option<u32>,
+}
+#[skip_serializing_none]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+pub struct IdMappings {
+    #[serde(rename = "AutoUserNs")]
+    pub auto_user_ns: Option<bool>,
+    #[serde(rename = "AutoUserNsOpts")]
+    pub auto_user_ns_opts: Option<AutoUserNSOpts>,
+    #[serde(rename = "GIDMap")]
+    pub gid_map: Option<Vec<IdMap>>,
+    #[serde(rename = "HostGIDMapping")]
+    pub host_gid_map: Option<bool>,
+    #[serde(rename = "HostUIDMapping")]
+    pub host_uid_map: Option<bool>,
+    #[serde(rename = "UIDMap")]
+    pub uid_map: Option<Vec<IdMap>>,
+}
+
+
 
 #[skip_serializing_none]
 #[cfg_attr(feature = "builder", derive(Builder))]
@@ -19,17 +59,22 @@ use std::convert::TryFrom;
 #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
 pub struct CreatePodParameter {
     pub cgroup_parent: Option<String>,
+    pub cni_networks: Option<Vec<String>>,
     pub cpu_period: Option<i64>,
     pub cpu_quota: Option<i64>,
     pub dns_option: Option<Vec<String>>,
     pub dns_search: Option<Vec<String>>,
     pub dns_server: Option<String>,
+    pub exit_policy: Option<String>,
     pub hostadd: Option<Vec<String>>,
     pub hostname: Option<String>,
+    pub idmappings: IdMappings,
     pub image_volumes: Option<ImageVolume>,
     pub infra_command: Option<Vec<String>>,
     pub infra_conmon_pid_file: Option<String>,
     pub infra_image: Option<String>,
+    pub infra_name: Option<String>,
+    pub ipcns: Option<Namespace>,
     pub labels: Option<HashMap<String, String>>,
     pub mounts: Option<Vec<Mount>>,
     pub name: Option<String>,
@@ -46,12 +91,20 @@ pub struct CreatePodParameter {
     pub pod_devices: Option<Vec<String>>,
     pub portmappings: Option<Vec<PortMapping>>,
     pub resource_limits: Option<LinuxResources>,
+    pub restart_policy: Option<String>,
+    pub restart_tries: Option<u64>,
     pub security_opt: Option<Vec<String>>,
+    #[serde(rename = "serviceContainerID")]
+    pub service_container_id: Option<String>,
+    pub share_parent: Option<bool>,
     pub shared_namespaces: Option<Vec<String>>,
+    pub shm_size: Option<i64>,
+    pub shm_size_systemd: Option<i64>,
     pub sysctl: Option<HashMap<String, String>>,
     #[serde(rename = "ThrottleReadBpsDevice")]
     pub throttle_read_bps_device: Option<HashMap<String, LinuxThrottleDevice>>,
     pub userns: Option<Namespace>,
+    pub ustns: Option<Namespace>,
     pub volumes: Option<Vec<NamedVolume>>,
     pub volumes_from: Option<Vec<String>>,
 }

--- a/src/pods/response_types.rs
+++ b/src/pods/response_types.rs
@@ -12,6 +12,8 @@ pub struct CreatePodResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct InspectPodResponse {
+    pub blkio_weight: Option<u64>,
+    pub blkio_weight_device: Option<Vec<InspectBlkioThrottleDevice>>,
     #[serde(rename = "CgroupParent")]
     pub c_group_parent: Option<String>,
     #[serde(rename = "CgroupPath")]
@@ -20,7 +22,9 @@ pub struct InspectPodResponse {
     pub containers: Option<Vec<InspectPodContainerInfo>>,
     pub cpu_period: Option<u64>,
     pub cpu_quota: Option<i64>,
-    pub cpusets_cpu: Option<String>,
+    pub cpu_shares: Option<i64>,
+    pub cpusets_cpus: Option<String>,
+    pub cpusets_mems: Option<String>,
     #[serde(rename = "CreateCgroup")]
     pub create_cgoup: Option<bool>,
     #[serde(rename = "CreateCommand")]
@@ -30,6 +34,7 @@ pub struct InspectPodResponse {
     #[serde(rename = "CreateInfra")]
     pub create_infra: Option<bool>,
     pub device_read_bps: Option<InspectBlkioThrottleDevice>,
+    pub device_write_bps: Option<InspectBlkioThrottleDevice>,
     pub devices: Option<Vec<InspectDevice>>,
     #[serde(rename = "ExitPolicy")]
     pub exit_policy: Option<String>,
@@ -43,6 +48,9 @@ pub struct InspectPodResponse {
     pub infra_container_id: Option<String>,
     #[serde(rename = "Labels")]
     pub labels: Option<HashMap<String, String>>,
+    #[serde(rename = "LockNumber")]
+    pub lock_number: Option<u32>,
+    pub memory_limit: Option<u64>,
     pub mounts: Option<Vec<InspectMount>>,
     #[serde(rename = "Name")]
     pub name: Option<String>,
@@ -50,6 +58,8 @@ pub struct InspectPodResponse {
     pub namespace: Option<String>,
     #[serde(rename = "NumContainers")]
     pub num_containers: Option<u64>,
+    #[serde(rename = "RestartPolicy")]
+    pub restart_policy: Option<String>,
     pub security_opt: Option<Vec<String>>,
     #[serde(rename = "SharedNamespaces")]
     pub shared_namespaces: Vec<String>,
@@ -83,7 +93,7 @@ pub struct InspectDevice {
 pub struct InspectPodInfraConfig {
     pub cpu_period: Option<u64>,
     pub cpu_quota: Option<i64>,
-    pub spuset_cpus: Option<String>,
+    pub cpuset_cpus: Option<String>,
     #[serde(rename = "DNSOption")]
     pub dns_option: Option<Vec<String>>,
     #[serde(rename = "DNSSearch")]
@@ -186,6 +196,8 @@ pub struct ListPodContainer {
     pub id: Option<String>,
     #[serde(rename = "Names")]
     pub names: Option<String>,
+    #[serde(rename = "RestartCount")]
+    pub restart_count: Option<u64>,
     #[serde(rename = "Status")]
     pub status: Option<String>,
 }

--- a/src/system/api_call_functions.rs
+++ b/src/system/api_call_functions.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::podman_service::PodmanService;
 use crate::system::parameter_types::{EventsParameter, EventsParameterStreamingQuery};
-use crate::system::response_types::{Event, GetInfoResponse, DfResponse};
+use crate::system::response_types::{DfResponse, Event, GetInfoResponse};
 use crate::utils;
 use futures::Stream;
 use std::convert::TryInto;
@@ -51,9 +51,7 @@ impl<'service> System<'service> {
         Ok(result_stream)
     }
 
-    pub async fn df(
-        &self
-    ) -> Result<DfResponse> {
+    pub async fn df(&self) -> Result<DfResponse> {
         let endpoint = utils::create_endpoint("/libpod/system/df");
 
         let response = self

--- a/src/system/api_call_functions.rs
+++ b/src/system/api_call_functions.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::podman_service::PodmanService;
 use crate::system::parameter_types::{EventsParameter, EventsParameterStreamingQuery};
-use crate::system::response_types::{Event, GetInfoResponse};
+use crate::system::response_types::{Event, GetInfoResponse, DfResponse};
 use crate::utils;
 use futures::Stream;
 use std::convert::TryInto;
@@ -49,5 +49,17 @@ impl<'service> System<'service> {
             .get_json_stream(&endpoint, Some(query), None, None)
             .await?;
         Ok(result_stream)
+    }
+
+    pub async fn df(
+        &self
+    ) -> Result<DfResponse> {
+        let endpoint = utils::create_endpoint("/libpod/system/df");
+
+        let response = self
+            .podman_service
+            .get_request(&endpoint, None, None, None)
+            .await?;
+        utils::deserialize_service_response(response)
     }
 }

--- a/src/system/response_types.rs
+++ b/src/system/response_types.rs
@@ -260,44 +260,69 @@ pub struct EventActor {
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct DfImage {
-    pub Repository: String,
-    pub Tag: String,
-    pub ImageID: String,
-    pub Created: String,
-    pub Size: u64,
-    pub SharedSize: u64,
-    pub UniqueSize: u64,
-    pub Containers: u64,
+    #[serde(rename = "Repository")]
+    pub repository: String,
+    #[serde(rename = "Tag")]
+    pub tag: String,
+    #[serde(rename = "ImageID")]
+    pub image_id: String,
+    #[serde(rename = "Created")]
+    pub created: String,
+    #[serde(rename = "Size")]
+    pub size: u64,
+    #[serde(rename = "SharedSize")]
+    pub shared_size: u64,
+    #[serde(rename = "UniqueSize")]
+    pub inique_size: u64,
+    #[serde(rename = "Containers")]
+    pub containers: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct DfContainer {
-    pub ContainerID: String,
-    pub Image: String,
-    pub Command: Vec<String>,
-    pub LocalVolumes: u64,
-    pub Size: u64,
-    pub RWSize: u64,
-    pub Created: String,
-    pub Status: String,
-    pub Names: String,
+    #[serde(rename = "ContainerID")]
+    pub container_id: String,
+    #[serde(rename = "Image")]
+    pub image: String,
+    #[serde(rename = "Command")]
+    pub command: Vec<String>,
+    #[serde(rename = "LocalVolumes")]
+    pub local_volumes: u64,
+    #[serde(rename = "Size")]
+    pub size: u64,
+    #[serde(rename = "RWSize")]
+    pub rw_size: u64,
+    #[serde(rename = "Created")]
+    pub created: String,
+    #[serde(rename = "Status")]
+    pub status: String,
+    #[serde(rename = "Names")]
+    pub names: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct DfVolume {
-    pub Links: u64,
-    pub ReclaimableSize: u64,
-    pub Size: u64,
-    pub VolumeName: String,
+    #[serde(rename = "Links")]
+    pub links: u64,
+    #[serde(rename = "ReclaimableSize")]
+    pub reclaimable_size: u64,
+    #[serde(rename = "Size")]
+    pub size: u64,
+    #[serde(rename = "VolumeName")]
+    pub volume_name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct DfResponse {
-    pub ImagesSize: u64,
-    pub Images: Vec<DfImage>,
-    pub Containers: Vec<DfContainer>,
-    pub Volumes: Vec<DfVolume>,
+    #[serde(rename = "ImagesSize")]
+    pub images_size: u64,
+    #[serde(rename = "Images")]
+    pub images: Vec<DfImage>,
+    #[serde(rename = "Containers")]
+    pub containers: Vec<DfContainer>,
+    #[serde(rename = "Volumes")]
+    pub volumes: Vec<DfVolume>,
 }

--- a/src/system/response_types.rs
+++ b/src/system/response_types.rs
@@ -12,6 +12,29 @@ pub struct GetInfoResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct NetDNS {
+    pub package: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkBackendInfo {
+    pub backend: Option<String>,
+    pub version: Option<String>,
+    pub package: Option<String>,
+    pub path: Option<String>,
+    pub dns: Option<NetDNS>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Pasta {
+    pub executable: Option<String>,
+    pub version: Option<String>,
+    pub package: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct HostInfo {
@@ -44,6 +67,10 @@ pub struct HostInfo {
     pub swap_free: Option<i64>,
     pub swap_total: Option<i64>,
     pub uptime: Option<String>,
+    pub free_locks: Option<i64>,
+    pub network_backend_info: Option<NetworkBackendInfo>,
+    pub pasta: Option<Pasta>,
+    pub variant: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -145,7 +172,7 @@ pub struct StoreInfo {
     pub config_file: Option<String>,
     pub container_store: Option<ContainerStore>,
     pub graph_driver_name: Option<String>,
-    pub graph_options: Option<HashMap<String, GraphOptionsEntry>>,
+    pub graph_options: Option<HashMap<String, String>>,
     pub graph_root: Option<String>,
     pub graph_root_allocated: Option<u64>,
     pub graph_root_used: Option<u64>,
@@ -224,4 +251,40 @@ pub struct EventActor {
     pub id: Option<String>,
     #[serde(rename = "Attributes")]
     pub attributes: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct DfImage {
+    pub Repository: String,
+    pub Tag: String,
+    pub ImageID: String,
+    pub Created: String,
+    pub Size: u64,
+    pub SharedSize: u64,
+    pub UniqueSize: u64,
+    pub Containers: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct DfContainer {
+    pub ContainerID: String,
+    pub Image: String,
+    pub Command: Vec<String>,
+    pub LocalVolumes: u64,
+    pub Size: u64,
+    pub RWSize: u64,
+    pub Created: String,
+    pub Status: String,
+    pub Names: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct DfResponse {
+    pub ImagesSize: u64,
+    pub Images: Vec<DfImage>,
+    pub Containers: Vec<DfContainer>,
+    pub Volumes: Vec<String>,
 }

--- a/src/system/response_types.rs
+++ b/src/system/response_types.rs
@@ -60,6 +60,7 @@ pub struct HostInfo {
     pub oci_runtime: Option<OciRuntime>,
     pub os: Option<String>,
     pub remote_socket: Option<RemoteSocket>,
+    pub rootless_network_cmd: Option<String>,
     pub runtime_info: Option<HashMap<String, String>>,
     pub security: Option<SecurityInfo>,
     pub service_is_remote: Option<bool>,

--- a/src/system/response_types.rs
+++ b/src/system/response_types.rs
@@ -14,6 +14,8 @@ pub struct GetInfoResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct NetDNS {
     pub package: Option<String>,
+    pub path: Option<String>,
+    pub version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -49,6 +51,7 @@ pub struct HostInfo {
     pub database_backend: Option<String>,
     pub distribution: Option<DistributionInfo>,
     pub event_logger: Option<String>,
+    pub free_locks: Option<i64>,
     pub hostname: Option<String>,
     pub id_mappings: Option<IdMappings>,
     pub kernel: Option<String>,
@@ -57,8 +60,10 @@ pub struct HostInfo {
     pub mem_free: Option<i64>,
     pub mem_total: Option<i64>,
     pub network_backend: Option<String>,
+    pub network_backend_info: Option<NetworkBackendInfo>,
     pub oci_runtime: Option<OciRuntime>,
     pub os: Option<String>,
+    pub pasta: Option<Pasta>,
     pub remote_socket: Option<RemoteSocket>,
     pub rootless_network_cmd: Option<String>,
     pub runtime_info: Option<HashMap<String, String>>,
@@ -68,9 +73,6 @@ pub struct HostInfo {
     pub swap_free: Option<i64>,
     pub swap_total: Option<i64>,
     pub uptime: Option<String>,
-    pub free_locks: Option<i64>,
-    pub network_backend_info: Option<NetworkBackendInfo>,
-    pub pasta: Option<Pasta>,
     pub variant: Option<String>,
 }
 
@@ -213,6 +215,7 @@ pub struct Version {
     pub os: Option<String>,
     pub os_arch: Option<String>,
     pub version: Option<String>,
+    pub index: Option<i64>,
 }
 
 // Info taken from https://github.com/containers/podman/blob/69085570f7ebbb3768e963e2a6a31d7bb9b4ca16/libpod/info.go#L265-L281
@@ -283,9 +286,18 @@ pub struct DfContainer {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
+pub struct DfVolume {
+    pub Links: u64,
+    pub ReclaimableSize: u64,
+    pub Size: u64,
+    pub VolumeName: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct DfResponse {
     pub ImagesSize: u64,
     pub Images: Vec<DfImage>,
     pub Containers: Vec<DfContainer>,
-    pub Volumes: Vec<String>,
+    pub Volumes: Vec<DfVolume>,
 }

--- a/src/volumes/parameter_types.rs
+++ b/src/volumes/parameter_types.rs
@@ -16,6 +16,10 @@ use std::convert::TryFrom;
 pub struct CreateVolumeParameter {
     #[serde(rename = "Driver")]
     pub driver: Option<String>,
+    #[serde(rename = "IgnoreIfExists")]
+    pub ignore_if_exists: Option<bool>,
+    #[serde(rename = "Label")]
+    pub label: Option<HashMap<String, String>>,
     #[serde(rename = "Labels")]
     pub labels: Option<HashMap<String, String>>,
     #[serde(rename = "Name")]
@@ -31,6 +35,8 @@ impl ExampleValues for CreateVolumeParameter {
         label.insert(String::from("example"), String::from("yes"));
         Self {
             driver: Some(String::from("local")),
+            ignore_if_exists: None,
+            label: None,
             labels: Some(label),
             volume_name: Some(String::from("CreateVolumeParameter")),
             options: None,

--- a/src/volumes/response_types.rs
+++ b/src/volumes/response_types.rs
@@ -16,6 +16,8 @@ pub struct InspectVolumeResponse {
     pub gid: Option<i64>,
     #[serde(rename = "Labels")]
     pub labels: Option<HashMap<String, String>>,
+    #[serde(rename = "LockNumber")]
+    pub lock_number: Option<i64>,
     #[serde(rename = "MountCount")]
     pub mound_count: Option<u64>,
     #[serde(rename = "Mountpoint")]
@@ -32,6 +34,10 @@ pub struct InspectVolumeResponse {
     pub scope: Option<String>,
     #[serde(rename = "Status")]
     pub status: Option<HashMap<String, String>>,
+    #[serde(rename = "StorageID")]
+    pub storage_id: Option<String>,
+    #[serde(rename = "Timeout")]
+    pub timeout: Option<i64>,
     #[serde(rename = "UID")]
     pub uid: Option<i64>,
 }


### PR DESCRIPTION
This PR adds support for the API return and submission types introduced until libpod5 as defined in the [API documentation](https://docs.podman.io/en/latest/_static/api.html) 

I've additionally: 
- updated dependencies
- run cargo fmt/clippy
- cleaned up the warnings by adjusting the DF-related structs
- bumped the version.
